### PR TITLE
mesa-asahi: update template to use consistent version

### DIFF
--- a/srcpkgs/asahi-desktop-base/files/10-wireplumber.conf
+++ b/srcpkgs/asahi-desktop-base/files/10-wireplumber.conf
@@ -1,0 +1,5 @@
+# copy or symlink this file to /etc/pipewire/pipewire.conf.d (system configuration)
+# or ${XDG_CONFIG_HOME}/pipewire/pipewire.conf.d (per-user configuration)
+# to configure pipewire to launch wireplumber directly
+
+context.exec = [ { path = "/usr/bin/wireplumber" args = "" } ]

--- a/srcpkgs/asahi-desktop-base/files/20-pipewire-pulse.conf
+++ b/srcpkgs/asahi-desktop-base/files/20-pipewire-pulse.conf
@@ -1,0 +1,5 @@
+# copy or symlink this file to /etc/pipewire/pipewire.conf.d (system configuration)
+# or ${XDG_CONFIG_HOME}/pipewire/pipewire.conf.d (per-user configuration)
+# to configure pipewire to launch pipewire-pulse directly
+
+context.exec = [ { path = "/usr/bin/pipewire" args = "-c pipewire-pulse.conf" } ]

--- a/srcpkgs/asahi-desktop-base/files/30-modeset.conf
+++ b/srcpkgs/asahi-desktop-base/files/30-modeset.conf
@@ -1,0 +1,6 @@
+Section "OutputClass"
+    Identifier "appledrm"
+    MatchDriver "apple"
+    Driver "modesetting"
+    Option "PrimaryGPU" "true"
+EndSection

--- a/srcpkgs/asahi-desktop-base/files/pipewire.desktop
+++ b/srcpkgs/asahi-desktop-base/files/pipewire.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=PipeWire
+Comment=Start PipeWire
+Icon=pipewire
+Exec=pipewire
+Terminal=false
+Type=Application
+NoDisplay=true

--- a/srcpkgs/asahi-desktop-base/template
+++ b/srcpkgs/asahi-desktop-base/template
@@ -1,0 +1,24 @@
+# Template file for 'asahi-desktop-base'
+pkgname=asahi-desktop-base
+version=20240531
+revision=1
+archs="aarch64*"
+build_style=meta
+depends="asahi-base asahi-scripts asahi-audio mesa-asahi-dri mesa-asahi-vaapi mesa-asahi-vdpau "
+short_desc="Void Linux Apple Silicon base desktop support package"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="Public Domain"
+
+do_install() {
+
+	# pipewire
+	vinstall "${FILESDIR}/10-wireplumber.conf" 644 etc/pipewire/pipewire.conf.d/ 10-wireplumber.conf
+	vinstall "${FILESDIR}/20-pipewire-pulse.conf" 644 /etc/pipewire/pipewire.conf.d/ 20-pipewire-pulse.conf
+
+	# autostart pipewire
+	vinstall "${FILESDIR}/pipewire.desktop" 644 etc/xdg/autostart pipewire.desktop
+
+	# x11
+	vinstall "${FILESDIR}/30-modeset.conf" 644 etc/X11/x11.conf.d/ 30-modeset.conf
+
+}

--- a/srcpkgs/asahi-desktop-plasma/files/sddm.conf
+++ b/srcpkgs/asahi-desktop-plasma/files/sddm.conf
@@ -1,0 +1,5 @@
+[General]
+GreeterEnvironment=QT_SCREEN_SCALE_FACTORS=2,QT_FONT_DPI=192
+
+[Theme]
+Current=breeze

--- a/srcpkgs/asahi-desktop-plasma/template
+++ b/srcpkgs/asahi-desktop-plasma/template
@@ -1,0 +1,16 @@
+# Template file for 'asahi-desktop-plasma'
+pkgname=asahi-desktop-plasma
+version=20240531
+revision=1
+archs="aarch64*"
+build_style=meta
+depends="asahi-desktop-base plasma-desktop plasma-workspace konsole dolphin sddm sddm-kcm
+ kwalletmanager plasma-nm plasma-vault bluez libspa-bluetooth bluedevil"
+short_desc="Void Linux Apple Silicon KDE Plasma desktop support package"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="Public Domain"
+
+do_install() {
+	vinstall "${FILESDIR}/sddm.conf" 644 etc/ sddm.conf
+
+}

--- a/srcpkgs/mesa-asahi/template
+++ b/srcpkgs/mesa-asahi/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa-asahi'
 pkgname=mesa-asahi
 version=24.2.0
-revision=1
+revision=20240527
 build_style=meson
 _llvmver=17
 #Disable LTO flag should be present, see https://gitlab.freedesktop.org/mesa/mesa/-/issues/6911
@@ -23,8 +23,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://docs.mesa3d.org/relnotes.html"
-distfiles="https://gitlab.freedesktop.org/asahi/mesa/-/archive/main/mesa-main.tar.gz"
-checksum=1b8b32aa91c4da1fdcf92a00bec945e95097bb018f7071f7efa72d40b10ef5d8
+distfiles="https://gitlab.freedesktop.org/asahi/mesa/-/archive/asahi-20240527/mesa-asahi-20240527.tar.gz" 
+checksum=aca4991240f3d25617762d0c8b9644ad05e3b45791bb81f048fc304d44260fe0
 conflicts="mesa"
 
 build_options="wayland"
@@ -100,7 +100,6 @@ libglapi-asahi_package() {
 libgbm-asahi_package() {
 	short_desc="Mesa Generic buffer management API - runtime"
 	conflicts="libgbm"
-	provides="libgbm"
 	pkg_install() {
 		vmove "usr/lib/libgbm.so.*"
 	}

--- a/srcpkgs/mesa-asahi/template
+++ b/srcpkgs/mesa-asahi/template
@@ -23,7 +23,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://docs.mesa3d.org/relnotes.html"
-distfiles="https://gitlab.freedesktop.org/asahi/mesa/-/archive/asahi-20240527/mesa-asahi-20240527.tar.gz" 
+distfiles="https://gitlab.freedesktop.org/asahi/mesa/-/archive/asahi-20240527/mesa-asahi-20240527.tar.gz"
 checksum=aca4991240f3d25617762d0c8b9644ad05e3b45791bb81f048fc304d44260fe0
 conflicts="mesa"
 
@@ -31,8 +31,8 @@ build_options="wayland"
 build_options_default="wayland"
 
 # Set subpackages manually
-subpackages="libglapi-asahi libgbm-asahi libgbm-asahi-devel libOSMesa-asahi"
-subpackages+=" mesa-asahi-vaapi mesa-asahi-vdpau mesa-asahi-vulkan-overlay-layer mesa-asahi-dri MesaLib-asahi-devel"
+subpackages="libgbm-asahi libgbm-asahi-devel libOSMesa-asahi mesa-asahi-vaapi mesa-asahi-vdpau
+ mesa-asahi-vulkan-overlay-layer mesa-asahi-dri MesaLib-asahi-devel"
 
 # Replace old mesa pkgs, superseded by libglvnd.
 replaces="libGL>=10_1<19.2.5_2 libEGL>=10_1<19.2.5_2 libGLES>=10_1<19.2.5_2"
@@ -84,22 +84,10 @@ post_install() {
 	done
 }
 
-libglapi-asahi_package() {
-	# this dependency is wrong, it was added as a hack to allow updating
-	# systems with libglapi-32bit after the switch to glvnd
-	# see 927f17347f9c646047c65312c8e8ce1ad88b7832
-	# it can be removed when glibc multilib (with *-32bit packages) is removed
-	depends="libglvnd"
-	conflicts="libglapi"
-	short_desc="Free implementation of the GL API - shared library"
-	pkg_install() {
-		vmove "usr/lib/libglapi.so.*"
-	}
-}
-
 libgbm-asahi_package() {
 	short_desc="Mesa Generic buffer management API - runtime"
 	conflicts="libgbm"
+	shlib_provides="libgbm.so" # workaround for mesa-libgbm conflict
 	pkg_install() {
 		vmove "usr/lib/libgbm.so.*"
 	}

--- a/srcpkgs/mesa-asahi/update
+++ b/srcpkgs/mesa-asahi/update
@@ -1,2 +1,0 @@
-# mesa devs consider *.0 to be development releases
-ignore="*.0"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

The template for mesa-asahi is broken in that it always uses the latest main tar.gz file, which changes regularly hence the checksum will fail. This PR fixes the version number to the latest tag, which at time of writing is 20240527. It also removes the limitation on not updating a x.0 release (as mesa development is always on an x.0 release). This should build consistently now.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
